### PR TITLE
Fix bug: reset tab to 'Inventory' on logout

### DIFF
--- a/src/Delaford.vue
+++ b/src/Delaford.vue
@@ -68,7 +68,9 @@
         <Info :game="game" />
 
         <!-- Slots (Stats, Wear, Inventory, etc.) -->
-        <Slots :game="game" />
+        <Slots
+          ref="sidebarSlots"
+          :game="game" />
       </div>
 
       <context-menu :game="game"/>
@@ -149,6 +151,7 @@ export default {
     logout() {
       this.screen = 'login';
       this.game = { exit: true };
+      this.$refs.sidebarSlots.selected = 1;
     },
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a `ref` to the `Slots` component for easy access to the `selected` property. On logout, set the slot's selected value back to 1 (inventory tab).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/delaford/game/issues/47

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Game dev is fun! Reason enough if you ask me. 😁

Also fixes an issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Q&A (manual testing)
1. Log in
2. Switch tabs
3. Log out
4. Log in

## Screenshots (if appropriate):

## Types of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)