### PR TITLE
Add the top action from context-menu as first left-click on the top-left of game

### DIFF
--- a/server/core/context-menu.js
+++ b/server/core/context-menu.js
@@ -17,6 +17,9 @@ class ContextMenu {
     this.npcs = world.npcs;
     this.droppedItems = world.items;
 
+    // Only generate the first item?
+    this.firstOnly = miscData.firstOnly || false;
+
     // Element clicked on
     this.context = Object.values(miscData.clickedOn);
 
@@ -64,6 +67,16 @@ class ContextMenu {
         self.check(action, items);
         list += 1;
       } while (list < generateList.length);
+
+      items.sort((a, b) => b.timestamp - a.timestamp)
+        .sort((a, b) => a.action.weight - b.action.weight);
+
+      if (this.miscData.firstOnly) {
+        resolve({
+          firstItem: items[0],
+          count: items.length - 1,
+        });
+      }
 
       resolve(items);
     }, this);

--- a/server/player/handlers/actions/index.js
+++ b/server/player/handlers/actions/index.js
@@ -135,10 +135,17 @@ export default {
 
     const items = await contextMenu.build();
 
-    Socket.emit('game:context-menu:items', {
-      data: items,
-      player: incomingData.data.player,
-    });
+    if (incomingData.data.miscData.firstOnly) {
+      Socket.emit('game:context-menu:first-only', {
+        data: items,
+        player: incomingData.data.player,
+      });
+    } else {
+      Socket.emit('game:context-menu:items', {
+        data: items,
+        player: incomingData.data.player,
+      });
+    }
   },
   'player:context-menu:action': (incoming) => {
     const miscData = incoming.data.data.item.miscData || false;

--- a/src/components/sub/ContextMenu.vue
+++ b/src/components/sub/ContextMenu.vue
@@ -54,6 +54,9 @@ export default {
     bus.$on('PLAYER:MENU', this.buildMenu);
     bus.$on('game:context-menu:items', this.createMenu);
     bus.$on('contextmenu:close', this.closeMenu);
+    bus.$on('canvas:select-action', (event) => {
+      this.selectAction(event.event, event.item);
+    });
   },
   methods: {
     /**

--- a/src/components/util/ItemGrid.vue
+++ b/src/components/util/ItemGrid.vue
@@ -14,7 +14,7 @@
           backgroundPosition: `left -${(getItem(i).column * 32)}px top -${(getItem(i).row * 32)}px`
         }"
         :class="`slot ${gridData(screen).classId} ${isItemSelected(i)}`"
-        @click.left="selectItem(i)"
+        @click.left="selectItem($event)"
         @mouseover="showContextMenu($event, i, true)"
         @click.right="showContextMenu($event, i)">
         <span
@@ -52,6 +52,8 @@ export default {
   },
   data() {
     return {
+      action: '',
+      currentAction: false,
       itemSelected: false,
     };
   },
@@ -68,8 +70,16 @@ export default {
   },
   created() {
     this.$forceUpdate();
+    bus.$on('game:context-menu:first-only', this.displayFirstAction);
   },
   methods: {
+    displayFirstAction(incoming) {
+      const { count } = incoming.data.data;
+      let { label } = incoming.data.data.firstItem;
+      if (count > 0) label += ` / ${count} other options`;
+      this.action = label;
+      this.currentAction = incoming.data.data.firstItem;
+    },
     /**
      * Get the item's column of a certain slot in the inventory
      *
@@ -141,9 +151,15 @@ export default {
      *
      * @param {integer} slot The item in the slot we are selecting
      */
-    selectItem(slot) {
+    selectItem(event) {
       // Allow 'selecting' an item only on the Inventory or if its not already selected
-      this.itemSelected = this.itemSelected === slot || this.screen !== 'inventory' ? false : slot;
+
+      bus.$emit('canvas:select-action', {
+        event,
+        item: this.currentAction,
+      });
+
+      // this.itemSelected = this.itemSelected === slot || this.screen !== 'inventory' ? false : slot;
     },
     gridData(section) {
       const modifier = {

--- a/src/components/util/ItemGrid.vue
+++ b/src/components/util/ItemGrid.vue
@@ -15,7 +15,8 @@
         }"
         :class="`slot ${gridData(screen).classId} ${isItemSelected(i)}`"
         @click.left="selectItem(i)"
-        @click.right="rightClick($event, i)">
+        @mouseover="showContextMenu($event, i, true)"
+        @click.right="showContextMenu($event, i)">
         <span
           v-if="hasQuantity(i)"
           class="qty"
@@ -165,7 +166,7 @@ export default {
      *
      * @param {event} event The mouse-click event
      */
-    rightClick(event, index) {
+    showContextMenu(event, index, firstOnly = false) {
       this.$forceUpdate();
 
       const coordinates = UI.getViewportCoordinates(event);
@@ -177,9 +178,21 @@ export default {
         target: event.target,
       };
 
-      event.preventDefault();
+      if (!firstOnly) {
+        event.preventDefault();
 
-      bus.$emit('PLAYER:MENU', data);
+        bus.$emit('PLAYER:MENU', data);
+      }
+
+      if (firstOnly && event && event.target) {
+        bus.$emit('PLAYER:MENU', {
+          coordinates,
+          event,
+          slot: index,
+          target: event.target,
+          firstOnly: true,
+        });
+      }
     },
     /**
      * Check to see if this slot is available


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When you hover over the game map or anywhere an action can take place, you will see the first action available in the top-left and the # of available options. You will also be able to quickly left-click to perform that action.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This is a point-and-click game.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Q&A (manual testing)

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/616320/52530319-f232af00-2cc8-11e9-8b45-9d845727bdc7.png)


## Types of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)