### PR TITLE
issue #64 - You can login twice via fast-clicking the login form - Fixed

### DIFF
--- a/src/Delaford.vue
+++ b/src/Delaford.vue
@@ -214,6 +214,9 @@ export default {
         window.focusOnGame();
       }, 250);
 
+      // Clear login procedure
+      bus.$emit('login:done');
+
       // Show the game canvas
       this.loaded = true;
     },

--- a/src/components/ui/Login.vue
+++ b/src/components/ui/Login.vue
@@ -84,6 +84,7 @@ export default {
       guestAccount: false,
       musicIntroduced: false,
       rememberMe: false,
+      isLoginInProgress: false,
     };
   },
   computed: {
@@ -113,6 +114,7 @@ export default {
     this.guestAccount = this.$store.getters.guestAccount;
 
     bus.$on('player:login-error', data => this.incorrectLogin(data));
+    bus.$on('login:done', () => this.setLoginProgress(false));
 
     if (this.guestAccount && process.env.NODE_ENV === 'development') {
       // Development user
@@ -161,6 +163,8 @@ export default {
      * Send login request to server.
      */
     login() {
+      if (this.isLoginInProgress) return;
+      this.setLoginProgress(true);
       this.invalid = false;
       const data = {
         username: this.username,
@@ -169,14 +173,17 @@ export default {
       };
 
       this.$store.dispatch('rememberDevAccount', { username: this.username, password: this.password });
-
       Socket.emit('player:login', data);
     },
     /**
      * Displays when a user login is invalid
      */
     incorrectLogin() {
+      this.setLoginProgress(false);
       this.invalid = true;
+    },
+    setLoginProgress(isLoginInProgress) {
+      this.isLoginInProgress = isLoginInProgress;
     },
   },
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
#64 Fixed issue - Preventing duel login 

## Related Issue
https://github.com/delaford/game/issues/64

## Motivation and Context
This fix prevents someone who is clicking the login button twice quickly (or tapping the enter key multiple time on a relevant field) from login more than once.

## How Has This Been Tested?
Manual Q&A only. Attempted to double click / double press enter and watch the console for the number of logins . Prior to the fix you would get more than one.

## Screenshots (if appropriate):

## Types of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)