### PR TITLE
Fixing issue #74 - No skill stats showing in pane & console TypeError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ yarn-error.log*
 *.njsproj
 *.sln
 *.sw*
+*.history
 
 # Project specific
 scratchpad.txt

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   },
   "scripts": {
     "dev:node": "set NODE_ENV=development && ./node_modules/.bin/nodemon --exec ./node_modules/.bin/babel-node --no-babelrc server.js --presets @babel/preset-env --plugins @babel/plugin-transform-modules-commonjs",
-    "dev:node_global": "set NODE_ENV=development && nodemon --exec ./node_modules/.bin/babel-node --no-babelrc server.js --presets @babel/preset-env --plugins @babel/plugin-transform-modules-commonjs",
     "server:prod": "NODE_ENV=production node server.js",
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build --modern",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "dev:node": "set NODE_ENV=development && ./node_modules/.bin/nodemon --exec ./node_modules/.bin/babel-node --no-babelrc server.js --presets @babel/preset-env --plugins @babel/plugin-transform-modules-commonjs",
+    "dev:node_global": "set NODE_ENV=development && nodemon --exec ./node_modules/.bin/babel-node --no-babelrc server.js --presets @babel/preset-env --plugins @babel/plugin-transform-modules-commonjs",
     "server:prod": "NODE_ENV=production node server.js",
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build --modern",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed #74 - updated the v-for syntax, added _id field to player.json skills and removed the capitalizing method in favor of css text-transform. The skill stats should now show up well and produce no errors in the console.

## Related Issue
https://github.com/delaford/game/issues/74


## Motivation and Context
Stats tab was not showing well,

## How Has This Been Tested?
Manual testing only: click the stats tab and see the skills. open the console and see no errors.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/12447815/53697024-947c1900-3dd5-11e9-91b2-dcd9649bea7c.png)

## Types of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Note
I had to use "eslint-disable-line" for two lines in the css of the "skill-name" class. I'm not sure why is this failing the commit script, but it otherwise fails at "npm run lint:css".  