### PR TITLE
Fix bug: change tab to inventory when banking

### DIFF
--- a/src/Delaford.vue
+++ b/src/Delaford.vue
@@ -150,6 +150,8 @@ export default {
       this.screen = 'server-down';
     };
 
+    bus.$on('show-sidebar', this.showSidebar);
+
     // On logout, let's do a few things...
     bus.$on('player:logout', this.logout);
     bus.$on('go:main', this.cancelLogin);
@@ -234,6 +236,9 @@ export default {
     },
     sidebarClicked() {
       bus.$emit('contextmenu:close');
+    },
+    showSidebar(selectedSlot) {
+      this.$refs.sidebarSlots.selected = selectedSlot;
     },
   },
 };

--- a/src/components/game-panes/Bank.vue
+++ b/src/components/game-panes/Bank.vue
@@ -10,6 +10,8 @@
 </template>
 
 <script>
+import bus from '../../core/utilities/bus';
+
 export default {
   props: {
     game: {
@@ -26,6 +28,10 @@ export default {
     bankItems() {
       return this.game.player.bank;
     },
+  },
+  mounted() {
+    const INVENTORY = 1;
+    bus.$emit('show-sidebar', INVENTORY);
   },
 };
 </script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Added a `bus` event listener to handle tab changes - `bus.$on('show-sidebar', tabNumber)`. This should make any other future tab changes easier to handle as well.

In this case specifically, when the bank is displayed (the component is `mounted`), it emits an event with the inventory slot number.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/delaford/game/issues/60

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Q&A (manual testing)

Manual testing - click on any tab other than inventory, click on the bank gnome

## Screenshots (if appropriate):

## Types of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)