### PR TITLE
Chatbox component now reloads when game world is loaded

### DIFF
--- a/server/core/functions/shop.js
+++ b/server/core/functions/shop.js
@@ -248,10 +248,7 @@ class Shop {
     // How much gold are we spending?
     const toSpend = price * isBuying;
     // How much gold do we have?
-    let playerGold = 0;
-    if (this.inventory[this.coinIndex]) {
-      playerGold = this.inventory[this.coinIndex].qty;
-    }
+    const playerGold = this.inventory[this.coinIndex].qty;
     // How much money left after purchase?
     const moneyLeft = playerGold - toSpend;
     // How many items to buy based on all calculations

--- a/src/Delaford.vue
+++ b/src/Delaford.vue
@@ -61,9 +61,7 @@
         <GameCanvas :game="game" />
 
         <!-- Chatbox -->
-        <Chatbox
-          v-if="screen === 'game'"
-          :game="game" />
+        <Chatbox :game="game" />
       </div>
       <div
         class="right"
@@ -225,9 +223,6 @@ export default {
 
       // Show the game canvas
       this.loaded = true;
-
-      // Set screen so chat will reset on game loading
-      this.screen = 'game';
     },
     /**
      * A click-handler event that does nothing, really.

--- a/src/Delaford.vue
+++ b/src/Delaford.vue
@@ -61,7 +61,9 @@
         <GameCanvas :game="game" />
 
         <!-- Chatbox -->
-        <Chatbox :game="game" />
+        <Chatbox
+          v-if="screen === 'game'"
+          :game="game" />
       </div>
       <div
         class="right"
@@ -223,6 +225,9 @@ export default {
 
       // Show the game canvas
       this.loaded = true;
+
+      // Set screen to 'game' for chatbox reset
+      this.screen = 'game';
     },
     /**
      * A click-handler event that does nothing, really.


### PR DESCRIPTION
## Description
Made the Chatbox component load conditionally upon the game world opening. This cleared up the old text.

This was accomplished by changing this.screen to 'game' at the end of the game world loading instructions.

## Related Issue
https://github.com/delaford/game/issues/46

## Motivation and Context
Creates a fresh experience for the user on each log in.

## How Has This Been Tested?
I added text to the chat window, both player chat and system notifications, and then logged out and back in.

## Types of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)