### PR TITLE
Switched the order in which items are taken/placed into inventory in shop

### DIFF
--- a/server/core/functions/shop.js
+++ b/server/core/functions/shop.js
@@ -190,15 +190,7 @@ class Shop {
     if (this.canWeSell()) {
       const rounds = this.stackable ? 1 : this.quantityToSell;
 
-      // Add coins to our coins in inventory
-      if (this.hasCoinsInInventory()) {
-        this.inventory.slots[this.coinIndex].qty += price * rounds;
-      } else {
-        // If not, lets give them their coins to the inventory
-        this.inventory.add('coins', price * rounds);
-      }
-
-      if (this.itemInStock() || this.buyingStoreProduct()) {        
+      if (this.itemInStock() || this.buyingStoreProduct()) {
         this.shop[this.shopItemIndex].qty += this.quantityToSell;
       }
 
@@ -213,6 +205,14 @@ class Shop {
       // Remove item from inventory
       for (let index = 0; index < rounds; index += 1) {
         this.inventory.slots.splice(this.inventory.slots.findIndex(z => z.id === this.itemId), 1);
+      }
+
+      // Add coins to our coins in inventory
+      if (this.hasCoinsInInventory()) {
+        this.inventory.slots[this.coinIndex].qty += price * rounds;
+      } else {
+        // If not, lets give them their coins to the inventory
+        this.inventory.add('coins', price * rounds);
       }
     }
 
@@ -274,7 +274,7 @@ class Shop {
       // the whole coin sprite from the inventory
         this.inventory.slots.splice(this.coinIndex, 1);
       }
-      
+
       // Substract the quantity of the items we have bought
       const qtyAfterPurchase = this.shop[this.shopItemIndex].qty - isBuying;
 
@@ -283,7 +283,7 @@ class Shop {
       } else {
         // Remove sprite with quantity equals to zero only
         // when item's origin is from a player.
-          this.shop.splice(this.shopItemIndex, 1);
+        this.shop.splice(this.shopItemIndex, 1);
       }
     }
 


### PR DESCRIPTION
## Description
Inside the `shop.js` file, the coins were being added to the inventory when there were no coins already there and the item was taken afterwards. This created the effect of the coins taking up the second available slot when the player held no coins in their inventory.

## Related Issue
#96 

## Motivation and Context
The previous behavior of buying and selling was awkward and unnatural to the user experience.

## How Has This Been Tested?
This was a very isolated instance of code, therefore, there should be no affect on other areas as the change was minimal. Going into the game and testing with the shopkeeper showed intended effects, coins were placed into the inventory in the first available slot and the item was successfully sold.

## Screenshots (if appropriate):

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)