### PR TITLE
Check prohibited attribute on items when selling

### DIFF
--- a/server/core/data/items/general.js
+++ b/server/core/data/items/general.js
@@ -18,7 +18,7 @@ export default [
     actions: presetActions([
       'resource',
     ]),
-    untradeable: false,
+    prohibited: true,
   },
   // Ores
   {

--- a/server/core/functions/shop.js
+++ b/server/core/functions/shop.js
@@ -29,6 +29,9 @@ class Shop {
     this.stackable = this.itemFull.stackable;
     this.ableToBuyAll = false;
 
+    // Is this item prohibited from being sold?
+    this.prohibited = this.itemFull.prohibited;
+
     // Get the quantity of how much we are able to buy
     this.quantity = this.getTrueStockableQuantity(quantity);
     this.quantityToSell = this.getSellableQuantity(quantity);
@@ -156,7 +159,10 @@ class Shop {
   canWeSell() {
     let willWeSell = false;
     let msg = '';
-    if (this.isSpeciality()) {
+    if (this.prohibited) {
+      willWeSell = false;
+      msg = 'You cannot sell this item.';
+    } else if (this.isSpeciality()) {
       willWeSell = this.shop.map(q => q.id).includes(this.itemId);
       if (!willWeSell) {
         msg = 'You cannot sell this item to the store.';


### PR DESCRIPTION
## Description
When an item is attempted to be sold, check for the presence of a `prohibited` attribute on the item and if false, prevent the sale. Added `prohibited` with the value of `false` to the coins item. Removed unused `untradeable` attribute on the coins item.

## Related Issue
Fixes #95 

## Motivation and Context
Prevents the player from losing their coins.

## How Has This Been Tested?
Q&A (manual testing)

## Screenshots (if appropriate):

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)