### PR TITLE
When an item is sold, update the index where coins are in inventory

### DIFF
--- a/server/core/functions/shop.js
+++ b/server/core/functions/shop.js
@@ -211,6 +211,7 @@ class Shop {
       // Remove item from inventory
       for (let index = 0; index < rounds; index += 1) {
         this.inventory.slots.splice(this.inventory.slots.findIndex(z => z.id === this.itemId), 1);
+        this.coinIndex = this.inventory.slots.findIndex(e => e.id === 'coins'); // Update the index where coins are in inventory
       }
 
       // Add coins to our coins in inventory


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update coinIndex on a shop instance after removing a sold item from inventory to accurately be able to reference the coins slot later in the code.

## Related Issue
Fixes #101 

## Motivation and Context
Fixes crash

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Q&A (manual testing)

## Screenshots (if appropriate):

## Types of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)