### PR TITLE
Show a message instead of a price when valuing prohibited items

### DIFF
--- a/server/core/functions/shop.js
+++ b/server/core/functions/shop.js
@@ -329,9 +329,16 @@ class Shop {
    */
   value() {
     const { price, name } = Query.getItemData(this.itemId);
+    let value = '';
+    // If the item is prohibited, it has no value
+    if (this.prohibited) {
+      value = 'How can you value that which has infinite value?';
+    } else {
+      value = `${price} coins.`;
+    }
     Socket.emit('game:send:message', {
       player: { socket_id: world.players[this.playerIndex].socket_id },
-      text: `${name}: ${price} coins.`,
+      text: `${name}: ${value}`,
     });
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Instead of attempting to show a price for prohibited items and showing a price of 0 (or false as in #99), show a witty sentence instead.

## Related Issue
Fixes #99 

## Motivation and Context
Clarifies to the player that this type of item cannot be sold and doesn't display a nonsensical value of false.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Q&A (manual testing)

## Screenshots (if appropriate):

## Types of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)