### PR TITLE
Fix issue #94 - 'Popup screen does not close when moving away'

### DIFF
--- a/src/components/GameCanvas.vue
+++ b/src/components/GameCanvas.vue
@@ -121,6 +121,7 @@ export default {
      * @param {event} event The mouse-click event
      */
     leftClick(event) {
+      bus.$emit('screen:close');
       bus.$emit('canvas:select-action', {
         event,
         item: this.currentAction,


### PR DESCRIPTION
## Description
Emit the ```screen:close``` event when the user click on the map

## Related Issue
Fix #94 

## Motivation and Context
Enhancement

## How Has This Been Tested?
Q&A (manual testing)

## Screenshots (if appropriate):

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)