### PR TITLE
Fix issue #73 - Change npm scripts to be cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,18 +6,18 @@
     "node": ">10.3.0"
   },
   "scripts": {
-    "dev:node": "set NODE_ENV=development && ./node_modules/.bin/nodemon --exec ./node_modules/.bin/babel-node --no-babelrc server.js --presets @babel/preset-env --plugins @babel/plugin-transform-modules-commonjs",
-    "server:prod": "NODE_ENV=production node server.js",
+    "dev:node": "npx cross-env NODE_ENV=development nodemon --exec ./node_modules/.bin/babel-node --no-babelrc server.js --presets @babel/preset-env --plugins @babel/plugin-transform-modules-commonjs",
+    "server:prod": "npx cross-env NODE_ENV=production node server.js",
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build --modern",
     "lint": "vue-cli-service lint",
     "start": "pm2-runtime start ecosystem.config.js --env production",
     "postinstall": "npm run build-server && npm run build",
     "test:unit": "vue-cli-service test:unit",
-    "ndb": "./node_modules/.bin/ndb npm run dev:node",
+    "ndb": "ndb npm run dev:node",
     "format": "eslint --fix",
-    "clean-server": "rm -rf build && mkdir build",
-    "transpile-server": "./node_modules/.bin/babel --no-babelrc ./server --out-dir ./build --copy-files --source-maps --presets @babel/preset-env --plugins @babel/plugin-transform-runtime",
+    "clean-server": "npx rimraf build && mkdir build",
+    "transpile-server": "babel --no-babelrc ./server --out-dir ./build --copy-files --source-maps --presets @babel/preset-env --plugins @babel/plugin-transform-runtime",
     "build-server": "npm run clean-server && npm run transpile-server",
     "lint:css": "stylelint '**/*.vue' --syntax scss"
   },


### PR DESCRIPTION
## Description
Rewrote npm script using npm packages that enable cross-platform support.

## Related Issue
#73 

## Motivation and Context
Enables devs on every platform to be able to contribute to the project.

## How Has This Been Tested?
Q&A (manual testing)
Tested on Ubuntu 19.04 and Windows 10 Pro

## Screenshots (if appropriate):

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Note:
I couldn't get the ndb command to work on windows. For me it only works with a global installation of ndb and manually typing `ndb npm run dev:node`. On Linux, it works just fine.