### PR TITLE
Fixed the coin value to display it's actual value.

### DIFF
--- a/server/core/functions/shop.js
+++ b/server/core/functions/shop.js
@@ -331,7 +331,7 @@ class Shop {
     const { price, name } = Query.getItemData(this.itemId);
     Socket.emit('game:send:message', {
       player: { socket_id: world.players[this.playerIndex].socket_id },
-      text: `${name}: ${price} coins.`,
+      text: this.itemId !== 'coins' ? `${name}: ${price} coins.` : `${this.item.qty} coins.`,
     });
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When checking the value of coins, it will now display the coins quantity (value) instead of false.

## Related Issue
#99 

## Motivation and Context
The coins would display a false value when inspecting it's value.

## How Has This Been Tested?
Q&A (manual testing)

## Screenshots (if appropriate):
<img width="683" alt="image" src="https://user-images.githubusercontent.com/27185256/66158287-74663f80-e5da-11e9-9076-538f291efa78.png">

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)