### PR TITLE
Fixed Qty on dropped items

### DIFF
--- a/server/core/item.js
+++ b/server/core/item.js
@@ -54,7 +54,7 @@ class Item {
             x: item.x,
             y: item.y,
             respawn: true,
-            timestamp: Date.now(),
+            timestamp: Date.now()
           });
 
           Socket.broadcast('world:itemDropped', world.items);

--- a/server/core/utilities/common/player/inventory.js
+++ b/server/core/utilities/common/player/inventory.js
@@ -30,6 +30,7 @@ export default class Inventory {
           id: itemId,
           uuid: itemUuid,
           slot: UI.getOpenSlot(this.slots),
+          qty : qty
         };
 
         // If the item is stackable, lets give its proper quantity

--- a/server/player/handlers/actions/index.js
+++ b/server/player/handlers/actions/index.js
@@ -74,7 +74,7 @@ export default {
     world.items.push({
       id: data.item.id,
       uuid: itemUuid,
-      qty: itemInventory.qty || null,
+      qty: itemInventory.qty || 1,
       x: world.players[playerIndex].x,
       y: world.players[playerIndex].y,
       timestamp: Date.now(),


### PR DESCRIPTION
## Description
Dropped items will drop the correct amount. The QTY should now be reflected in the World/Items route, and get added on pickup.

## Related Issue
#69 

## Motivation and Context
When stack-able items are dropped (Money), it will only ever drop 1.

## How Has This Been Tested?
Q&A (manual testing)

## Screenshots (if appropriate):
<img width="493" alt="image" src="https://user-images.githubusercontent.com/27185256/66189258-2a16aa00-e63e-11e9-9b95-b28595ca12cb.png">

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)