### PR TITLE
Change: remove "Sell" actions from context-menu for "coins"

### DIFF
--- a/src/components/sub/ContextMenu.vue
+++ b/src/components/sub/ContextMenu.vue
@@ -151,6 +151,11 @@ export default {
         .sort((a, b) => b.timestamp - a.timestamp) // Sort by when item appeared
         .sort((a, b) => a.action.weight - b.action.weight); // then by action weight
 
+      // for Coins, do not give the option to "Sell"
+      if (data.data.data[0].id === 'coins') {
+        this.items = this.items.filter(menuItem => menuItem.action.name !== 'Sell');
+      }
+
       // Ready to show
       this.view = true;
 


### PR DESCRIPTION
## Description
Removes the "sell" actions from the list of available actions on the front end side for coins.

I personally have concerns over this implementation because both the string `'coins'` and ''sell'` are hard coded instead of an ID. So if and when this needs to be changed it has an increased chance of being missed. Another thought is that a lot of work is currently done server-side and this looks like a unique case of that filtering on FE. 

## Related Issue
https://github.com/delaford/game/issues/100

## Motivation and Context
UX

## How Has This Been Tested?
Manually - I right clicked and the menu does not have sell options.

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)