### PR TITLE
Change socket to recognize current viewport and filter players on that

### DIFF
--- a/server/player/handlers/socket-events/index.js
+++ b/server/player/handlers/socket-events/index.js
@@ -5,6 +5,7 @@
 import Authentication from '@server/player/authentication';
 import Player from '@server/core/player';
 import Socket from '@server/socket';
+import config from '@server/config';
 import playerGuest from '@server/core/data/helpers/player.json';
 import world from '@server/core/world';
 
@@ -43,16 +44,33 @@ export default {
    */
   'player:say': ({ data }) => {
     const { id, said } = data;
-    const { username } = world.players.find(p => p.socket_id === id);
+    const { viewport } = config.map;
+
+    const { username, x, y } = world.players.find(p => p.socket_id === id);
 
     // Put a limit on the length of a player message to 50 characters.
     const text = said.length > 50 ? said.substring(0, 50) : said;
+
+    // Get viewport values based on player and viewport x, y
+    const viewportValues = {
+      minX: x - Math.floor(0.5 * viewport.x),
+      minY: y - Math.floor(0.5 * viewport.y),
+      maxX: x + Math.floor(0.5 * viewport.x),
+      maxY: y + Math.floor(0.5 * viewport.y),
+    };
+
+    // Get nearby Players
+    const nearbyPlayers = world.players.filter((p) => {
+      const playerInX = p.x >= viewportValues.minX && p.x <= viewportValues.maxX;
+      const playerInY = p.y >= viewportValues.minY && p.y <= viewportValues.maxY;
+      return playerInX && playerInY;
+    });
 
     Socket.broadcast('player:say', {
       username,
       type: 'chat',
       text,
-    });
+    }, nearbyPlayers);
   },
 
   /**

--- a/server/socket.js
+++ b/server/socket.js
@@ -39,23 +39,25 @@ class Socket {
    * @param {string} event The type of event I am broadcasting
    * @param {object} data Data associated with the event
    */
-  static broadcast(event, data) {
+  static broadcast(event, data, players) {
     const obj = {
       event,
       data,
     };
 
     world.clients.forEach((client, index) => {
-      const getSender = world.players.find(p => p.socket_id === client.id);
+      if (!players || players.find(p => p.socket_id === client.id)) {
+        const sender = world.players.find(p => p.socket_id === client.id);
 
-      if (world.players.length && getSender) {
-        if (client.readyState === 3) {
-          world.clients.splice(index, 1);
-        }
-        const getPlayer = world.clients.find(c => c.id === client.id);
+        if (world.players.length && sender) {
+          if (client.readyState === 3) {
+            world.clients.splice(index, 1);
+          }
+          const player = world.clients.find(c => c.id === client.id);
 
-        if (getPlayer && (client.readyState === getPlayer.readyState) && (world.clients.length)) {
-          client.send(JSON.stringify(obj));
+          if (player && (client.readyState === player.readyState) && (world.clients.length)) {
+            client.send(JSON.stringify(obj));
+          }
         }
       }
     });

--- a/src/core/map.js
+++ b/src/core/map.js
@@ -1,9 +1,9 @@
-import config from 'root/config';
 import PF from 'pathfinding';
-import moveToMouse from '@/assets/graphics/ui/mouse/moveTo.png';
-import blockedMouse from '@/assets/graphics/ui/mouse/blocked.png';
 import UI from 'shared/ui';
+import config from 'root/config';
+import blockedMouse from '@/assets/graphics/ui/mouse/blocked.png';
 import bus from './utilities/bus';
+import moveToMouse from '@/assets/graphics/ui/mouse/moveTo.png';
 
 class Map {
   constructor(data, images) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I made a validation on socket event when verifying players valid based on player and viewport x,y and pass those players to the broadcast event.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#27 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This resolve chat local issue,  before, all users connected will see the sent message, now just the players inside the sender viewport can do that.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Q&A (manual testing)

## Screenshots (if appropriate):

## Types of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)