### PR TITLE
Add `inventory#count` method

### DIFF
--- a/server/core/data/helpers/player.json
+++ b/server/core/data/helpers/player.json
@@ -14,31 +14,38 @@
 		"current": 10,
 		"max": 10
 	},
-	"skills": [{
-		"level": 1,
-		"exp": 0,
-		"name": "Attack"
-	}, {
-		"level": 1,
-		"exp": 0,
-		"name": "Defence"
-	}, {
-		"level": 1,
-		"exp": 0,
-		"name": "Mining"
-	}, {
-		"level": 1,
-		"exp": 0,
-		"name": "Smithing"
-	}, {
-		"level": 1,
-		"exp": 0,
-		"name": "Fishing"
-	}, {
-		"level": 1,
-		"exp": 0,
-		"name": "Cooking"
-	}],
+	"skills": {
+		"attack": {
+			"level": 1,
+			"exp": 0,
+			"name": "Attack"
+		},
+		"defence": {
+			"level": 1,
+			"exp": 0,
+			"name": "Defence"
+		},
+		"mining": {
+			"level": 1,
+			"exp": 0,
+			"name": "Mining"
+		},
+		"smithing": {
+			"level": 1,
+			"exp": 0,
+			"name": "Smithing"
+		},
+		"fishing": {
+			"level": 1,
+			"exp": 0,
+			"name": "Fishing"
+		},
+		"cooking": {
+			"level": 1,
+			"exp": 0,
+			"name": "Cooking"
+		}
+	},
 	"wear": {
 		"head": null,
 		"back": null,

--- a/server/core/skills/smithing.js
+++ b/server/core/skills/smithing.js
@@ -33,13 +33,12 @@ export default class Smithing extends Skill {
     };
   }
 
-  smelt(inventory) {
+  smelt() {
     const barToSmelt = Smithing.ores()[this.resourceId];
 
     const hasEnoughOre = () => {
       for (const ore of Object.keys(barToSmelt.requires)) {
-        const oreFound = inventory.filter(inv => inv.id === ore);
-        if (barToSmelt.requires[ore] > oreFound.length) {
+        if (barToSmelt.requires[ore] > this.player.inventory.count(ore)) {
           return false;
         }
       }

--- a/server/core/utilities/common/player/inventory.js
+++ b/server/core/utilities/common/player/inventory.js
@@ -43,4 +43,15 @@ export default class Inventory {
       }
     });
   }
+
+  /**
+   * Gets the quantity of an item in the player's inventory
+   *
+   * @param {string} itemId - The ID of the item
+   */
+  count(itemId) {
+    return this.slots
+      .filter(item => item.id === itemId)
+      .reduce((total, item) => total + (item.qty || 1), 0);
+  }
 }

--- a/server/player/handlers/actions/index.js
+++ b/server/player/handlers/actions/index.js
@@ -186,7 +186,7 @@ export default {
     const { player } = data;
 
     if (player.skills.smithing.level >= smithingLevelToSmelt[itemClickedOn]) {
-      const barSmelted = await smithing.smelt(player.inventory.slots);
+      const barSmelted = await smithing.smelt();
 
       if (barSmelted) {
         smithing.updateExperience(barSmelted.experience);
@@ -235,7 +235,7 @@ export default {
       item => item.id === 'hammer',
     );
 
-    if (!getBars) {
+    if (getBars.length <= 0) {
       Socket.sendMessageToPlayer(playerIndex, 'You need bars to smelt.');
     } else if (hasHammer) {
       const barToSmith = getBars ? getBars[0] : null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- Add the `inventory#count(itemId)` method which returns the number of the given item in the inventory.


## Description
<!--- Describe your changes in detail -->
- Add the `inventory#count(itemId)` method which returns the number of the given item in the inventory.
    - Utilise this new method in the `smelt` method
- Fix dev `player.json` format of `skills` to match expected map format
- Fix `player:resource:smith:anvil:pane` check of `getBars`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/delaford/game/pull/118

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Checking the number of an item in the inventory is a common issue; this method will be utilised once again in the `smith` method.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Q&A (manual testing)

## Screenshots (if appropriate):

## Types of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)