### PR TITLE
Fix Bug Trading/Banking on NPC while ON TOP causes delay

### DIFF
--- a/server/player/action.js
+++ b/server/player/action.js
@@ -111,6 +111,12 @@ class Action {
       clickedTile.y,
     )); // TODO: Add foreground.
 
+    // If the player clicked on himself make the action be immediate
+    if (clickedTile.x === 7 && clickedTile.y === 5) {
+      incomingAction.queueable = false;
+      queuedAction.queueable = false;
+    }
+
     // If an action needs to be performed
     // after a player reaches their destination
     if (queuedAction && queuedAction.queueable) {

--- a/server/player/handlers/actions/index.js
+++ b/server/player/handlers/actions/index.js
@@ -220,6 +220,10 @@ export default {
   },
 
   'player:resource:smelt:furnace:pane': (data) => {
+    if (data.playerIndex === undefined) {
+      data.playerIndex = world.players.findIndex(p => p.uuid === data.player.uuid);
+      data.todo = data;
+    }
     const { playerIndex } = data;
     const player = world.players[playerIndex];
     world.players[data.playerIndex].currentPane = 'furnace';
@@ -246,6 +250,10 @@ export default {
   },
 
   'player:resource:smith:anvil:pane': (data) => {
+    if (data.playerIndex === undefined) {
+      data.playerIndex = world.players.findIndex(p => p.uuid === data.player.uuid);
+      data.todo = data;
+    }
     const { playerIndex } = data;
     const player = world.players[playerIndex];
     world.players[data.playerIndex].currentPane = 'anvil';
@@ -353,6 +361,10 @@ export default {
    * A player wants opening a trade shop
    */
   'player:screen:npc:trade': (data) => {
+    if (data.playerIndex === undefined) {
+      data.playerIndex = world.players.findIndex(p => p.uuid === data.player.uuid);
+      data.todo = data;
+    }
     console.log('Accessing trade shop...', data.todo.item.id);
     world.players[data.playerIndex].currentPane = 'shop';
     world.players[data.playerIndex].objectId = data.todo.item.id;
@@ -411,6 +423,10 @@ export default {
   },
 
   'player:screen:smelt': (data) => {
+    if (data.playerIndex === undefined) {
+      data.playerIndex = world.players.findIndex(p => p.uuid === data.player.uuid);
+      data.todo = data;
+    }
     world.players[data.playerIndex].currentPane = 'smelt';
 
     Socket.emit('open:screen', {
@@ -424,6 +440,10 @@ export default {
    * A player wants to access their bank
    */
   'player:screen:bank': (data) => {
+    if (data.playerIndex === undefined) {
+      data.playerIndex = world.players.findIndex(p => p.uuid === data.player.uuid);
+      data.todo = data;
+    }
     world.players[data.playerIndex].currentPane = 'bank';
 
     Socket.emit('open:screen', {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I made the action be immediate (not queueable) if the player click himself on the center of the viewport

I add some validation on action pane (bank, furnace, anvil, smelt and trade) cause data.playerIndex is not send as a parameter when the action is not queueable.

## Related Issue
#119 

## Motivation and Context
This fixes the bug when you are on top of an NPC and want to trade/shop/bank with them and the popup screen will not popup UNTIL you move and FINISH its progress.

## How Has This Been Tested?
Q&A (manual testing)

## Screenshots (if appropriate):

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)