### PR TITLE
Fix levels of progress

### DIFF
--- a/server/core/player.js
+++ b/server/core/player.js
@@ -89,6 +89,14 @@ class Player {
     // Player inventory
     this.inventory = new Inventory(data.inventory, this.socket_id);
 
+    // Fix Skill Levels according to XP on Player constructor
+    const skillsName = ['attack', 'defence', 'mining', 'smithing', 'fishing', 'cooking'];
+    skillsName.forEach((skillName) => {
+      const skill = this.skills[skillName];
+      skill.exp = skill.exp > 0 ? skill.exp : 0;
+      skill.level = UI.getLevel(skill.exp);
+    });
+
     console.log(
       `${emoji.get('high_brightness')}  Player ${this.username} (lvl ${this.level}) logged in. (${
         this.x

--- a/server/shared/ui.js
+++ b/server/shared/ui.js
@@ -226,7 +226,7 @@ class UI {
   static getExperience(level) {
     let a = 0;
     for (let x = 1; x < level; x += 1) {
-      a += Math.floor(x + (530 * (2 ** (x / 7))));
+      a += Math.floor(x + (265 * (2 ** (x / 7))));
     }
 
     return Math.floor(a / 4);
@@ -239,6 +239,8 @@ class UI {
    * @return {integer}
    */
   static getLevel(exp) {
+    if (exp === 0) return 1;
+
     let level = 1;
     let calcExp = 0;
     while (exp > calcExp) {


### PR DESCRIPTION
## Description
Fix level of skill experience progress, changes made:
* Added a routine to check skill levels in the player builder
* Removed the "zero" skill level, the minimum level will always be 1
* Adjusted the level formula for level 2 starts at 73 experience and level 99 around 11 million exp.

## Related Issue
#153 

## Motivation and Context
The skill level was not being checked on the player constructor, so this could lead to the level of the skill being different from the real experience value

## How Has This Been Tested?
Q&A (manual testing)

## Screenshots (if appropriate):

## Types of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)