### PR TITLE
Bug fix: Player can't spam experience while smithing

### DIFF
--- a/server/core/skills/smithing.js
+++ b/server/core/skills/smithing.js
@@ -59,6 +59,9 @@ export default class Smithing extends Skill {
     };
   }
 
+  /**
+   * @returns {bool} Was forging successful
+   */
   forge(inventory) {
     console.log(this.resourceId);
 
@@ -93,12 +96,14 @@ export default class Smithing extends Skill {
       Socket.emit('core:pane:close', {
         player: { socket_id: world.players[this.playerIndex].socket_id },
       });
-    } else {
-      Socket.sendMessageToPlayer(
-        this.playerIndex,
-        'You do not have enough bars to smith this item.',
-      );
+      return true;
     }
+
+    Socket.sendMessageToPlayer(
+      this.playerIndex,
+      'You do not have enough bars to smith this item.',
+    );
+    return false;
   }
 
   smelt(inventory) {

--- a/server/player/handlers/actions/index.js
+++ b/server/player/handlers/actions/index.js
@@ -179,10 +179,11 @@ export default {
 
     const smith = new Smithing(playerIndex, itemClickedOn, 'forge');
     const { player } = data;
-    smith.forge(player.inventory.slots);
 
-    // Update the experience
-    smith.updateExperience(itemClickedOn.expGained);
+    // Only add experience if forging was successful
+    if (smith.forge(player.inventory.slots)) {
+      smith.updateExperience(itemClickedOn.expGained);
+    }
 
     // Tell client of their new experience in that skill
     Socket.emit('resource:skills:update', {


### PR DESCRIPTION
Bug fix for issue #151

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The function smithing.forge() now returns a bool that details if the forge was successful, this bool is then used to block experience updates if the smithing attempt was unsuccessful.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[ You get smithing EXP even if you have no bars #151 ](https://github.com/delaford/game/issues/151)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Players can't spam experience while trying to forge an item that they're unable to forge.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Q&A (manual testing)
Attempted to craft a bronze mace with only 4 bars in inventory, checking total experience before and after the act of forging.

## Screenshots (if appropriate):

## Types of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)