### PR TITLE
Image quantity fixed on dropped items

### DIFF
--- a/src/core/map.js
+++ b/src/core/map.js
@@ -240,7 +240,6 @@ class Map {
         && (this.player.x >= (item.x - 8))
         && (this.player.y <= (6 + item.y))
         && (this.player.y >= (item.y - 6));
-
       return foundItems;
     });
 
@@ -251,8 +250,15 @@ class Map {
         y: Math.floor(this.config.map.viewport.y / 2) - (this.player.y - item.y),
       };
 
-      // Get item information
+      // Get item information and get proper quantity index for graphic
       const info = UI.getItemData(item.id);
+      let qtyIndex = 0;
+      if (item.qty > 1 && info.graphics.quantityLevel) {
+        const qLevels = info.graphics.quantityLevel;
+        while (qtyIndex < qLevels.length - 1 && qLevels[qtyIndex] < item.qty) {
+          qtyIndex += 1;
+        }
+      }
 
       // Get the correct tileset to draw upon
       const itemTileset = () => {
@@ -272,7 +278,7 @@ class Map {
       // Paint the item on map
       this.context.drawImage(
         itemTileset(),
-        (info.graphics.column * 32), // Number in Item tileset
+        ((info.graphics.column + qtyIndex) * 32), // Number in Item tileset
         (info.graphics.row * 32), // Y-axis of tileset
         32,
         32,


### PR DESCRIPTION
Dropped items graphic now reflects the quantity. Code has been added to the drawItems() function in Map so that the proper tile column is selected for the appropriate quantity amount.
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Players now have immediate feedback for how much of a given quantity the player will receive upon taking an item.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[ Stacked quantity does not reflect on game map #115 ](https://github.com/delaford/game/issues/115)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug fix/extension of an existing feature.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Q&A (manual testing)
Just dropped coins of varying quantities around the map (see below).

## Screenshots (if appropriate):
![coinstacks](https://user-images.githubusercontent.com/54560038/182011026-dc6368e3-1b2c-4521-ae67-f01c9a0a8def.JPG)

## Types of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)