### PR TITLE
Fix smithing errors. and Updated smith getter.

### DIFF
--- a/server/core/data/items/armor.js
+++ b/server/core/data/items/armor.js
@@ -89,7 +89,7 @@ export default [
       row: 1,
       column: 0,
     },
-    actions: presetActions(['wearable']),
+    actions: presetActions(['wearable', 'anvil']),
   },
   {
     id: 'bronze-boots',

--- a/server/core/data/items/weapons.js
+++ b/server/core/data/items/weapons.js
@@ -29,7 +29,7 @@ export default [
       row: 0,
       column: 0,
     },
-    actions: presetActions(['wearable']),
+    actions: presetActions(['wearable', 'anvil']),
   },
   {
     id: 'bronze-axe',

--- a/server/core/skills/smithing.js
+++ b/server/core/skills/smithing.js
@@ -1,5 +1,5 @@
 import world from '@server/core/world';
-import { smithing, weapons } from '@server/core/data/items';
+import { smithing, weapons, armor } from '@server/core/data/items';
 import Socket from '@server/socket';
 // import Query from '@server/core/data/query';
 
@@ -65,7 +65,6 @@ export default class Smithing extends Skill {
     // eslint-disable-next-line
     const itemToForge = Smithing.getItemsToSmith(this.resourceId.id).find(item => this.resourceId.id === item.id);
     const barToTakeAway = itemToForge.item.split('-')[0];
-
     const inventoryHasThisManyBars = inventory.filter(inv => inv.id === `${barToTakeAway}-bar`).length;
     const hasEnoughBars = inventoryHasThisManyBars >= this.resourceId.bars;
 
@@ -77,13 +76,18 @@ export default class Smithing extends Skill {
       for (let index = 0; index < this.resourceId.bars; index += 1) {
         this.inventory.splice(getIndexOfBar, 1);
       }
-
       world.players[this.playerIndex].inventory.slots = this.inventory;
+      console.log(this.resourceId);
       world.players[this.playerIndex].inventory.add(this.resourceId.id, 1);
+      const getSmithedItemName = this.resourceId.type === 'weapon'
+        ? weapons.find(i => i.id === this.resourceId.id).name
+        : armor.find(i => i.id === this.resourceId.id).name;
+
       Socket.sendMessageToPlayer(
         this.playerIndex,
-        `You successfully smithed a ${weapons.find(i => i.id === this.resourceId.id).name}.`,
+        `You successfully smithed a ${getSmithedItemName}.`,
       );
+
 
       Socket.emit('core:refresh:inventory', {
         player: { socket_id: world.players[this.playerIndex].socket_id },
@@ -181,6 +185,7 @@ export default class Smithing extends Skill {
           level: 1,
           expGained: 13,
           bars: 1,
+          type: 'weapon',
         },
         {
           item: 'bronze-axe',
@@ -188,6 +193,7 @@ export default class Smithing extends Skill {
           level: 1,
           expGained: 15,
           bars: 2,
+          type: 'weapon',
         },
         {
           id: 'bronze-mace',
@@ -195,18 +201,23 @@ export default class Smithing extends Skill {
           level: 2,
           expGained: 19,
           bars: 5,
+          type: 'weapon',
         },
         {
+          id: 'bronze-med-helm',
           item: 'bronze-med-helm',
           level: 3,
           expGained: 21,
           bars: 1,
+          type: 'armor',
         },
         {
+          id: 'bronze-sword',
           item: 'bronze-sword',
           level: 4,
           expGained: 25,
           bars: 2,
+          type: 'weapon',
         },
       ];
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Anvil will now smith the med helmet. Anvil now supports armor smithing in general.
Bronze sword did not smith due to missing ID this was the same with the helmet armor which then made me realise that armor is not properly supported for forging.

Only “bronze-med-helmet” currently is supported due it being the only armor set available in the smithing list thus I made an assumption that the intended results was to allow smithing for this item. I also added ‘type’ to ‘getItemsToSmith()’ to differentiate between armor/weapon.  
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It was the first bug encountered when playing the game, and attempting to smith items thus I made an attempt to improve user experience.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Q&A (manual testing)
Tested on Ubuntu 21.04 and Windows 10 Home

## Screenshots (if appropriate):

## Types of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)